### PR TITLE
Demo layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Canvas, } from "@react-three/fiber";
 import RefDemo from "./RefDemo";
 import InteractiveCanvas from "./components/InteractiveCanvas/InteractiveCanvas";
 import { Color, Euler, Matrix4, Vector3 } from "three";
+import DemoLayout from "./components/DemoLayout/DemoLayout";
 
 const App = () => {
 	return (
@@ -11,7 +12,8 @@ const App = () => {
 				<pointLight position={[1, -1, 1]} intensity={5} />
 				<RefDemo />
 			</Canvas > */}
-			<InteractiveCanvas 
+			<DemoLayout />
+			{/* <InteractiveCanvas 
 				availableTransformations={[
 					{ type: 'rotation', amount: [0, 0, 1], matrix4: new Matrix4().makeRotationFromEuler(new Euler(0, 0, 1)) },
 					{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(2, 0, 0)) },
@@ -24,7 +26,7 @@ const App = () => {
 						{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(2, 2, 0)) }
 					]}
                 ]}
-				/>
+				/> */}
 		</>
 	)
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,3 @@
-import { Canvas, } from "@react-three/fiber";
-import RefDemo from "./RefDemo";
 import InteractiveCanvas from "./components/InteractiveCanvas/InteractiveCanvas";
 import { Color, Euler, Matrix4, Vector3 } from "three";
 import DemoLayout from "./components/DemoLayout/DemoLayout";
@@ -12,7 +10,24 @@ const App = () => {
 				<pointLight position={[1, -1, 1]} intensity={5} />
 				<RefDemo />
 			</Canvas > */}
-			<DemoLayout />
+			<DemoLayout>
+				<InteractiveCanvas
+					availableTransformations={[
+						{ type: 'rotation', amount: [0, 0, 1], matrix4: new Matrix4().makeRotationFromEuler(new Euler(0, 0, 1)) },
+						{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(2, 0, 0)) },
+						{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(0, 2, 0)) },
+					]}
+					scenes={[
+						{ geometry: <boxGeometry args={[1, 1, 0.1]} />, acceptTransformations: true },
+						{
+							geometry: <boxGeometry args={[1, 1, 0.1]} />, acceptTransformations: false, color: new Color(0x44cc44), staticTransformations: [
+								{ type: 'rotation', amount: [0, 0, 1], matrix4: new Matrix4().makeRotationFromEuler(new Euler(0, 0, 1)) },
+								{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(2, 2, 0)) }
+							]
+						}
+					]}
+				/>
+			</DemoLayout>
 			{/* <InteractiveCanvas 
 				availableTransformations={[
 					{ type: 'rotation', amount: [0, 0, 1], matrix4: new Matrix4().makeRotationFromEuler(new Euler(0, 0, 1)) },

--- a/src/components/CanvasWrapper/CanvasWrapper.module.css
+++ b/src/components/CanvasWrapper/CanvasWrapper.module.css
@@ -1,13 +1,14 @@
 .wrapper {
     position: relative;
     margin: 0 auto;
-    width: 60%;
-    height: 80vh;
+	width: 100%;
+    height: 100%;
 }
 
 .canvas {
     width: 100%;
     height: 100%;
+	background-color: #313B3E;
 }
 
 .controls_list {

--- a/src/components/DemoLayout/DemoLayout.module.css
+++ b/src/components/DemoLayout/DemoLayout.module.css
@@ -1,0 +1,70 @@
+body {
+	background-color: #313B3E;
+	height: 100vh;
+	margin: 0;
+	padding: 20px;
+	color: #F4FFFF;
+}
+
+.body_root {
+	background-color: white;
+	height: 1024px;
+	width: 100%;
+}
+
+.vertical_divide {
+	display: flex;
+	flex-direction: row;
+	height: 100%;
+}
+
+.right_section {
+	background-color: #4B585D;
+	width: 70%;
+	height: 100%;
+	/*	border: 1px solid white;*/
+}
+
+.nav_bar {
+	height: 120px;
+	display: flex;
+	background-color: #313B3E;
+	flex-direction: row;
+	justify-content: flex-end;
+	align-items: center;
+}
+
+.nav_button {
+	padding: 20px;
+	font-size: 1.4em;
+}
+
+.left_section {
+	background-color: #4B585D;
+	width: 30%;
+	height: 100%;
+	display: grid;
+}
+
+.lesson_content {
+	padding: 15px;
+	overflow-y: auto;
+	scrollbar-color: rgba(49, 59, 62, 100%) rgba(49, 59, 62, 50%);
+	scrollbar-width: thin;
+}
+
+/*#scroll-thumb {
+	width: 25px;
+	height: 100%;
+	background-color: rgba(49, 59, 62, 50%);
+	display: flex;
+	grid-column: 8 / span 9;
+}
+
+#scroll-bar {
+	width: 18px;
+	height: 80px;
+	background-color: black;
+	border-radius: 38%;
+	margin: 0 auto;
+}*/

--- a/src/components/DemoLayout/DemoLayout.tsx
+++ b/src/components/DemoLayout/DemoLayout.tsx
@@ -1,15 +1,18 @@
-import { Color, Euler, Matrix4, Vector3 } from "three";
-import InteractiveCanvas from "../InteractiveCanvas/InteractiveCanvas";
 import styles from "./DemoLayout.module.css";
 
-export default function DemoLayout() {
+/**
+ * A demonstration layout for developing lessons within page section constraints.
+ * @param children JSX Elements to be rendered within the interactable section of the page.
+ * @todo Fix: Change the sections do be their own individual UI components with required params for layout flexibility.
+ */
+export default function DemoLayout({children} : {children: JSX.Element}) {
 	return (
 		<div className={styles.body_root}>
 			<div className={styles.vertical_divide}>
 				<div className={styles.left_section}>
 					<section className={styles.lesson_content}>
 						<h1>Matrix Transformations</h1>
-						<p>
+						<p> 
 							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi congue, dolor sit amet viverra convallis, tortor est faucibus erat, eu ullamcorper mauris odio quis quam. Integer in gravida enim, eu lobortis orci.
 						</p>
 						<h2>
@@ -33,22 +36,7 @@ export default function DemoLayout() {
 						<div className={`${styles.lessons_button} ${styles.nav_button}`}>LESSONS</div>
 						<div className={`${styles.logo} ${styles.nav_button}`}>@</div>
 					</section>
-					<InteractiveCanvas
-						availableTransformations={[
-							{ type: 'rotation', amount: [0, 0, 1], matrix4: new Matrix4().makeRotationFromEuler(new Euler(0, 0, 1)) },
-							{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(2, 0, 0)) },
-							{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(0, 2, 0)) },
-						]}
-						scenes={[
-							{ geometry: <boxGeometry args={[1, 1, 0.1]} />, acceptTransformations: true },
-							{
-								geometry: <boxGeometry args={[1, 1, 0.1]} />, acceptTransformations: false, color: new Color(0x44cc44), staticTransformations: [
-									{ type: 'rotation', amount: [0, 0, 1], matrix4: new Matrix4().makeRotationFromEuler(new Euler(0, 0, 1)) },
-									{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(2, 2, 0)) }
-								]
-							}
-						]}
-					/>
+					{children}
 				</div>
 			</div>
 		</div>

--- a/src/components/DemoLayout/DemoLayout.tsx
+++ b/src/components/DemoLayout/DemoLayout.tsx
@@ -5,14 +5,14 @@ import styles from "./DemoLayout.module.css";
  * @param children JSX Elements to be rendered within the interactable section of the page.
  * @todo Fix: Change the sections do be their own individual UI components with required params for layout flexibility.
  */
-export default function DemoLayout({children} : {children: JSX.Element}) {
+export default function DemoLayout({ children }: { children: JSX.Element }) {
 	return (
 		<div className={styles.body_root}>
 			<div className={styles.vertical_divide}>
 				<div className={styles.left_section}>
 					<section className={styles.lesson_content}>
 						<h1>Matrix Transformations</h1>
-						<p> 
+						<p>
 							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi congue, dolor sit amet viverra convallis, tortor est faucibus erat, eu ullamcorper mauris odio quis quam. Integer in gravida enim, eu lobortis orci.
 						</p>
 						<h2>

--- a/src/components/DemoLayout/DemoLayout.tsx
+++ b/src/components/DemoLayout/DemoLayout.tsx
@@ -1,0 +1,56 @@
+import { Color, Euler, Matrix4, Vector3 } from "three";
+import InteractiveCanvas from "../InteractiveCanvas/InteractiveCanvas";
+import styles from "./DemoLayout.module.css";
+
+export default function DemoLayout() {
+	return (
+		<div className={styles.body_root}>
+			<div className={styles.vertical_divide}>
+				<div className={styles.left_section}>
+					<section className={styles.lesson_content}>
+						<h1>Matrix Transformations</h1>
+						<p>
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi congue, dolor sit amet viverra convallis, tortor est faucibus erat, eu ullamcorper mauris odio quis quam. Integer in gravida enim, eu lobortis orci.
+						</p>
+						<h2>
+							Order Matters
+						</h2>
+						<p>
+							Suspendisse potenti. Nullam eu nunc et libero ultrices ornare. Nulla et ultrices nisl. Vivamus lacinia sodales diam id ullamcorper. Morbi eleifend eros volutpat dolor vehicula efficitur. Sed porttitor metus pharetra odio scelerisque interdum. Ut lacinia felis in ullamcorper blandit. Aliquam ipsum magna, porttitor sed diam quis, imperdiet laoreet purus. Donec dictum odio a mi pharetra, nec auctor sem feugiat. Aenean nisl elit, egestas at fringilla ut, luctus ut libero. Ut ac risus ante. Nullam eu efficitur lectus.
+						</p>
+						<p>Suspendisse potenti. Mauris quis justo</p><h2> Matrix Multiplication</h2>
+						<p>
+							vehicula, cursus lorem quis, pellentesque justo. Proin quis ligula metus. In egestas sollicitudin magna sed posuere. Duis aliquet volutpat tristique. Nullam
+						</p>
+						<p>
+							semper aliquet nulla suscipit elementum. Nulla volutpat orci nisl, vel mollis nibh tincidunt sit amet. Praesent id sapien ipsum. Fusce tempusSed porttitor metus pharetra odio scelerisque interdum. Ut lacinia felis in ullamcorper blandit. Aliquam ipsum magna, porttitor sed diam quis, imperdiet laoreet purus. Donec dictum odio a mi pharetra,
+						</p>
+					</section>
+				</div>
+				<div className={styles.right_section}>
+					<section className={styles.nav_bar}>
+						<div className={`${styles.home_button} ${styles.nav_button}`}>HOME</div>
+						<div className={`${styles.lessons_button} ${styles.nav_button}`}>LESSONS</div>
+						<div className={`${styles.logo} ${styles.nav_button}`}>@</div>
+					</section>
+					<InteractiveCanvas
+						availableTransformations={[
+							{ type: 'rotation', amount: [0, 0, 1], matrix4: new Matrix4().makeRotationFromEuler(new Euler(0, 0, 1)) },
+							{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(2, 0, 0)) },
+							{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(0, 2, 0)) },
+						]}
+						scenes={[
+							{ geometry: <boxGeometry args={[1, 1, 0.1]} />, acceptTransformations: true },
+							{
+								geometry: <boxGeometry args={[1, 1, 0.1]} />, acceptTransformations: false, color: new Color(0x44cc44), staticTransformations: [
+									{ type: 'rotation', amount: [0, 0, 1], matrix4: new Matrix4().makeRotationFromEuler(new Euler(0, 0, 1)) },
+									{ type: 'raw', matrix4: new Matrix4().makeTranslation(new Vector3(2, 2, 0)) }
+								]
+							}
+						]}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/InteractiveCanvas/InteractiveCanvas.module.css
+++ b/src/components/InteractiveCanvas/InteractiveCanvas.module.css
@@ -1,8 +1,12 @@
 body {
-    background-color: #171717;
-    color: white;
+	background-color: #171717;
+	color: white;
 }
 
 .matrix_list {
-    display: flex;
+	display: flex;
+}
+
+.canvas {
+	height: 767px
 }

--- a/src/components/InteractiveCanvas/InteractiveCanvas.tsx
+++ b/src/components/InteractiveCanvas/InteractiveCanvas.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import TransformationOptions from './TransformationOptions';
 import { DndProvider, useDrop } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
+import styles from "./InteractiveCanvas.module.css"
 
 /**
  * Manages the state of transformations on the canvas. Needed for Drag and Drop.
@@ -53,7 +54,7 @@ export class TransformationStateManager {
 export default function InteractiveCanvas({availableTransformations, scenes}: {availableTransformations: Transformation[], scenes: Scene[]}) {
 
     return (
-        <div>
+        <div className={styles.canvas}>
             <DndProvider backend={HTML5Backend}>
                 <TransformationOptions transformations={availableTransformations} />
                 {/* Draggable matrices are applied to the canvas. Order is maintained :p */}


### PR DESCRIPTION
## Adds
- Demo Layout for matrix transformation canvas & lesson

## Changes
- Adjusted styling for internal interactive canvas components to better facilitate fitting in a page section rather than a full window

## Future TODOs
- Add a finalized version of these layouts with current internal `<section>` tags exported to their own UI components

![image](https://github.com/JadenKeller/Capstone-Interactive-Textbook/assets/112051310/3ef9253f-59d9-4d80-a76a-bfb4fda32297)
